### PR TITLE
Storing a non-accepted eval on a chain; candidate exchange chains with replacement.

### DIFF
--- a/src/mopt/AlgoBGP.jl
+++ b/src/mopt/AlgoBGP.jl
@@ -56,7 +56,7 @@ mutable struct BGPChain <: AbstractChain
     sigma_update_steps :: Int64   # update sampling vars every sigma_update_steps iterations
     sigma_adjust_by :: Float64   # adjust sampling vars by sigma_adjust_by percent up or down
     smpl_iters :: Int64   # max number of trials to get a new parameter from MvNormal that lies within support
-    min_improve  :: Float64  
+    min_improve  :: Float64
     batches  :: Vector{UnitRange{Int}}  # vector of indices to update together.
 
     """
@@ -93,7 +93,7 @@ mutable struct BGPChain <: AbstractChain
         this.m         = m
         # how many bundles + rest
         nb, rest = divrem(np,batch_size)
-        this.sigma = sig 
+        this.sigma = sig
         this.batches = UnitRange{Int}[]
         i = 1
         for ib in 1:nb
@@ -232,7 +232,7 @@ function set_eval!(c::BGPChain,ev::Eval)
         else
             c.curr_val[c.iter] = c.curr_val[c.iter-1]
         end
-        if (ev.value < c.best_val[c.iter-1])
+        if (ev.value < c.best_val[c.iter-1]) & (ev.accepted==true)
             c.best_val[c.iter] = ev.value
             c.best_id[c.iter]  = c.iter
         else
@@ -262,7 +262,7 @@ end
 
 Computes the next `Eval` for chain `c`:
 
-1. Get last accepted param 
+1. Get last accepted param
 2. get a new param via [`proposal`](@ref)
 3. [`evaluateObjective`](@ref)
 4. Accept or Reject the new value via [`doAcceptReject!`](@ref)
@@ -392,7 +392,7 @@ end
 """
     proposal(c::BGPChain)
 
-Gaussian Transition Kernel centered on current parameter value. 
+Gaussian Transition Kernel centered on current parameter value.
 
 1. Map all ``k`` parameters into ``\\mu \\in [0,1]^k``.
 2. update all parameters by sampling from `MvNormal`, ``N(\\mu,\\sigma)``, where ``sigma`` is `c.sigma` until all params are in ``[0,1]^k``
@@ -411,8 +411,8 @@ function proposal(c::BGPChain)
 
         # map into [0,1]
         # (x-a)/(b-a) = z \in [0,1]
-        mu01 = mapto_01(mu,lb,ub) 
-        
+        mu01 = mapto_01(mu,lb,ub)
+
         # Transition Kernel is q(.|theta(t-1)) ~ TruncatedN(theta(t-1), Sigma,lb,ub)
 
         # if there is only one batch of params

--- a/src/mopt/AlgoBGP.jl
+++ b/src/mopt/AlgoBGP.jl
@@ -626,7 +626,7 @@ function exchangeMoves!(algo::MAlgoBGP)
     props = [(i,j) for i in 1:algo["N"], j in 1:algo["N"] if (i<j)]
     # N pairs of chains are chosen uniformly in all possibel pairs with replacement
     samples = algo["N"] < 3 ? algo["N"]-1 : algo["N"]
-    pairs = sample(props,samples,replace=false)
+    pairs = sample(props,samples,replace=true)
 
     # @debug(logger,"")
     # @debug(logger,"exchangeMoves: proposing pairs")


### PR DESCRIPTION
1. Updated set_eval!() to store best value only if eval is accepted. A function evaluation that returns eval.status < 0 will also have eval.value = -1 because of the way the Eval object is initialised. This value is mistakenly saved in the chain if one does not condition on ev.accepted==true, as it is always smaller than anything else on the chain up to that point.

2. Candidate exchange pairs of chains are chosen WITH replacement according to Baragatti et al (2013) "N pairs of chains are chosen uniformly in all possible pairs with replacement".